### PR TITLE
Style check Cython .pyx file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [flake8]
 max-line-length = 120
 show_source = True
-exclude = .git, __pycache__, thirdparty, build, env
+filename = *.py, *.pyx
+exclude = .git, __pycache__, thirdparty, build, env, .github, dist, .eggs, *.egg
 ignore = W503
+per-file-ignores = *.pyx:E999, E225


### PR DESCRIPTION
Adds `flake8` check for `.pyx` files, ignoring some used Cython syntax that violates normal python style.