### PR TITLE
Fix compile error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def get_extra_compile_args():
             '--std=c++14',
             '-fPIC',
             '-Wall',
-            '-Werror',
+            # '-Werror',
             '-pedantic',
             # '-Wshadow', # Cython creates its own shadow mess
             '-Wextra',


### PR DESCRIPTION
Hello, thank you for the great package.

When I compared the speed against `scipy.optimize.nnls` and this package I saw a huge difference.

However, when installing with pip, I noticed an error during the compilation process, which I think is solved by turning off the compile flag `-Wall`, so I'd like to present a simple PR.

Also, I'd like to attach the error messages I saw during the installation.

```
Collecting fnnlsEigen
  Using cached fnnlsEigen-1.0.1.tar.gz (1.0 MB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting numpy>=1.20.2 (from fnnlsEigen)
  Using cached numpy-2.2.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (62 kB)
Collecting Cython>=0.29.23 (from fnnlsEigen)
  Using cached Cython-3.0.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.5 kB)
Using cached Cython-3.0.12-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.5 MB)
Using cached numpy-2.2.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.1 MB)
Building wheels for collected packages: fnnlsEigen
  Building wheel for fnnlsEigen (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for fnnlsEigen (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build/lib.linux-x86_64-cpython-313/test
      copying test/__init__.py -> build/lib.linux-x86_64-cpython-313/test
      copying test/test_fnnls.py -> build/lib.linux-x86_64-cpython-313/test
      running build_ext
      Compiling fnnlsEigen/eigen_fnnls.pyx because it changed.
      [1/1] Cythonizing fnnlsEigen/eigen_fnnls.pyx
      building 'fnnlsEigen' extension
      creating build/temp.linux-x86_64-cpython-313/fnnlsEigen
      g++ -pthread -B $CONDA_LOC/envs/test/shared/python_compiler_compat -fno-strict-overflow -Wsign-compare -DNDEBUG -O2 -Wall -fPIC -O2 -isystem $CONDA_LOC/envs/test/include -fPIC -O2 -isystem $CONDA_LOC/envs/test/include -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/tmp/pip-build-env-tp1e9djx/overlay/lib/python3.13/site-packages/numpy/_core/include -I/tmp/pip-install-wvip542a/fnnlseigen_f8a3316475ba4ed1b0be955e0c5c9f11/thirdparty/eigen -I$CONDA_LOC/envs/test/include/python3.13 -c fnnlsEigen/eigen_fnnls.cpp -o build/temp.linux-x86_64-cpython-313/fnnlsEigen/eigen_fnnls.o --std=c++14 -fPIC -Wall -Werror -pedantic -Wextra -faligned-new -O3 -DNDEBUG -DEIGEN_NO_DEBUG -funroll-loops -fomit-frame-pointer
      In file included from $CONDA_LOC/envs/test/include/python3.13/internal/pycore_code.h:12,
                       from $CONDA_LOC/envs/test/include/python3.13/internal/pycore_frame.h:13,
                       from fnnlsEigen/eigen_fnnls.cpp:11686:
      $CONDA_LOC/envs/test/include/python3.13/internal/pycore_backoff.h:19:16: error: ISO C++ prohibits anonymous structs [-Werror=pedantic]
         19 |         struct {
            |                ^
      cc1plus: all warnings being treated as errors
      error: command '/usr/bin/g++' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for fnnlsEigen
Failed to build fnnlsEigen
ERROR: Failed to build installable wheels for some pyproject.toml based projects (fnnlsEigen)
```

gcc, python version
```
gcc version 11.4.0 (Ubuntu 11.4.0-1ubuntu1~22.04)

Python 3.13.2 | packaged by conda-forge | (main, Feb 17 2025, 14:10:22) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
```

Sincerely,

Hyunwoo Ryu
